### PR TITLE
French Translation. Creation of  jbead_fr.properties

### DIFF
--- a/src/jbead_fr.properties
+++ b/src/jbead_fr.properties
@@ -1,0 +1,277 @@
+title = jbead - {1}
+
+draft = Patron
+corrected = Vue plane
+simulation = Simulation
+report = Bilan
+
+action.file = Fichier
+action.file.mnemonic = F
+
+action.file.new = Nouveau
+action.file.new.mnemonic = N
+action.file.new.keystroke = control N
+action.file.new.description = Créer un nouveau patron
+
+action.file.open = Ouvrir...
+action.file.open.mnemonic = O
+action.file.open.keystroke = control O
+action.file.open.description = Ouvrir un nouveau patron
+
+action.file.save = Sauver
+action.file.save.mnemonic = S
+action.file.save.keystroke = control S
+action.file.save.description = Sauvegarder le patron
+
+action.file.saveas = Sauver sous...
+action.file.saveas.mnemonic = A
+action.file.saveas.description = Sauvegarder le patron dans un nouveau fichier 
+
+action.file.print = Imprimer...
+action.file.print.mnemonic = P
+action.file.print.keystroke = control P
+action.file.print.description = Imprimer le patron
+
+action.file.pagesetup = Mise en page...
+action.file.pagesetup.mnemonic = U
+action.file.pagesetup.description = Configurer la mise en page
+
+action.file.exit = Quitter
+action.file.exit.mnemonic = X
+action.file.exit.keystroke = alt F4
+action.file.exit.description = Quitter le programme
+
+action.file.mru0 = 
+action.file.mru1 = 
+action.file.mru2 = 
+action.file.mru3 = 
+action.file.mru4 = 
+action.file.mru5 = 
+
+action.edit = Édition
+action.edit.mnemonic = E
+
+action.edit.undo = Annuler
+action.edit.undo.mnemonic = U
+action.edit.undo.keystroke = control Z 
+action.edit.undo.description = Annuler la dernière action 
+
+action.edit.redo = Rétablir
+action.edit.redo.mnemonic = E
+action.edit.redo.keystroke = control Y
+action.edit.redo.description = Rétablir la dernière modification
+
+action.edit.arrange = Arranger...
+action.edit.arrange.mnemonic = A
+action.edit.arrange.keystroke = F8
+action.edit.arrange.description = Arranger les copies de la partie sélectionnée
+
+action.edit.row = Lignes
+action.edit.row.mnemonic = W
+
+action.edit.insertrow = Insérer une ligne
+action.edit.insertrow.mnemonic = I 
+action.edit.insertrow.description = Insérer une ligne vierge en bas 
+
+action.edit.deleterow = Supprimer une ligne
+action.edit.deleterow.mnemonic = D
+action.edit.deleterow.description = Supprimer la ligne en bas
+
+action.edit.mirrorhorizontal = Miroir horizontal
+action.edit.mirrorhorizontal.mnemonic = H
+action.edit.mirrorhorizontal.description = Refléter horizontalement la sélection
+
+action.edit.mirrorvertical = Miroir vertical
+action.edit.mirrorvertical.mnemonic = V
+action.edit.mirrorvertical.description = Refléter verticalement la sélection
+
+action.edit.rotate = Rotation
+action.edit.rotate.mnemonic = R
+action.edit.rotate.description = Pivoter la sélection à 90 degrés
+
+action.edit.delete = Effacer
+action.edit.delete.mnemonic = D
+action.edit.delete.description = Effacer les perles sélectionnées
+
+action.view = Affichage
+action.view.mnemonic = V
+
+action.view.draft = Patron
+action.view.draft.mnemonic = D
+action.view.draft.description = Afficher la vue patron
+
+action.view.corrected = Vue plane
+action.view.corrected.mnemonic = C
+action.view.corrected.description = Montre la vue aplanie
+
+action.view.simulation = Simulation
+action.view.simulation.mnemonic = S
+action.view.simulation.description = Afficher la vue simulation
+
+action.view.report = Bilan
+action.view.report.mnemonic = R
+action.view.report.description = Afficher la vue Bilan
+
+action.view.drawcolors = Couleurs
+action.view.drawcolors.mnemonic = O
+action.view.drawcolors.description = Afficher les couleurs
+
+action.view.drawsymbols = Symboles
+action.view.drawsymbols.mnemonic = Y
+action.view.drawsymbols.description = Afficher les symboles
+
+action.view.zoomin = Zoomer
+action.view.zoomin.mnemonic = I
+action.view.zoomin.keystroke = control I
+action.view.zoomin.description = Agrandir la vue
+
+action.view.zoomnormal = Normal
+action.view.zoomnormal.mnemonic = N 
+action.view.zoomnormal.description = Taille de vue normale 
+
+action.view.zoomout = Dézoomer
+action.view.zoomout.mnemonic = O
+action.view.zoomout.keystroke = control U
+action.view.zoomout.description = Diminuer la vue
+
+action.tool = Outils
+action.tool.mnemonic = T
+
+action.tool.pencil = Stylo
+action.tool.pencil.mnemonic = P
+action.tool.pencil.keystroke = control 1
+action.tool.pencil.description = Dessiner avec un stylo
+
+action.tool.select = Sélection
+action.tool.select.mnemonic = S
+action.tool.select.keystroke = control 2
+action.tool.select.description = Sélectionner une partie du patron
+
+action.tool.fill = Remplir
+action.tool.fill.mnemonic = F
+action.tool.fill.keystroke = control 3
+action.tool.fill.description = Remplir une partie du patron avec la couleur courante
+
+action.tool.pipette = Pipette
+action.tool.pipette.mnemonic = T
+action.tool.pipette.keystroke = control 4
+action.tool.pipette.description = Utiliser la pipette
+
+action.pattern = Patron
+action.pattern.mnemonic = P
+
+action.pattern.width = Largeur...
+action.pattern.width.mnemonic = W
+action.pattern.width.description = Définir la largeur du patron
+
+action.pattern.height = Hauteur...
+action.pattern.height.mnemonic = H
+action.pattern.height.description = Définir la hauteur du patron
+
+action.pattern.preferences = Préférences...
+action.pattern.preferences.mnemonic = P
+action.pattern.preferences.description = Éditer les préférences
+
+action.info = ?
+action.info.mnemonic = ?
+
+action.info.techinfos = Informations techniques
+action.info.techinfos.mnemonic = T
+action.info.techinfos.description = Afficher les informations sur les versions de jbead et java
+
+action.info.updatecheck = Vérifier les mises à jour
+action.info.updatecheck.mnemonic = C
+action.info.updatecheck.description = Vérifier les mises à jour disponibles au téléchargement
+
+action.info.about = À propos de Jbead
+action.info.about.mnemonic = A
+action.info.about.description = Afficher les informations à propos de Jbead
+
+arrangedialog.title = Arrangement
+arrangedialog.copies = Nombre de copies :
+arrangedialog.horz = Déplacement horizontal :
+arrangedialog.vert = Déplacement vertical :
+
+patternwidthdialog.title = Largeur du patron
+patternwidthdialog.description = <html>La largeur du patron est équivalente<br> à la circonférence du cordon
+patternwidthdialog.width = Largeur du patron :
+
+patternheightdialog.title = Hauteur du patron
+patternheightdialog.height = Hauteur du patron :
+
+report.pattern = Patron :
+report.author = Auteur-ice :
+report.organization = Organisation :
+report.circumference = Circonférence :
+report.colorrepeat = Répétition de couleurs :
+report.rowsperrepeat = Lignes par répétition :
+report.numberofrows = Nombre total de lignes :
+report.numberofbeads = Nombre total de perles : 
+report.bead = perle
+report.beads = perles
+report.rows = lignes et
+report.row = ligne et
+report.listofbeads = Liste de perles
+
+colorchooser.title = Choisir la couleur
+
+colorpalette.popup.select = Sélectionner la couleur
+colorpalette.popup.edit = Éditer la couleur...
+colorpalette.popup.asbackground = Utiliser comme fond
+
+ok = OK
+cancel = Annuler
+unnamed = Sans nom
+savechanges = Voulez-vous sauvegarder vos changements ?
+invalidformat = Le fichier n'est pas un patron jbead. Il ne peut pas être chargé.
+fileexists = Le fichier {1} existe déjà. Voulez-vous l'écraser ?
+load.failed = Impossible de charger le fichier {1}. {2}
+save.failed = Erreur lors de la sauvegarde du fichier {1}. {2}
+copyinfos = Copier les infos
+
+techinfos.title = Informations techniques
+techinfos.version = Version
+techinfos.fileformat = Format de fichier
+techinfos.javaversion = Version de Java
+techinfos.javavendor = Fournisseur java
+techinfos.javahome = Java Home
+techinfos.osname = Nom du SE
+techinfos.osarch = Architecture du SE
+techinfos.osversion = Version du SE
+techinfos.screensize = Taille de l'écran
+techinfos.screenresolution = Résolution de l'écran
+techinfos.cpucores = Cœurs du CPU
+
+infoaboutdialog.title = À propos de jbead
+infoaboutdialog.text = <html><h2>jbead VERSION</h2><br>\
+  Voici <b>jbead</b>, un programme conçu pour vous aider<br>\
+  à concevoir des cordons de perles au crochet. La création<br>\
+  de tels codons est décrite, par exemple, dans le livre<br>\
+  <i>Bead Crochet Jewelry</i> écrit par Bert Rachel Freed et Dana<br>\
+  Elizabeth Freed. Il s'agit d'un travail difficile, mais le résultat<br>\
+  est très beau. Avec <b>jbead</b>, vous simulez l'aspect de votre<br>\
+  motif avant de commencer à travailler. Vous pouvez peaufiner votre<br>\
+  dessin et, enfin, imprimer toutes les données pertinentes, y compris<br>\
+  l'indispensable « liste de perles », qui vous indique comment<br>\
+  disposer correctement les perles sur le fil. <b>jbead</b> a été<br>\
+  écrit par Damian Brunold. Il est disponible gratuitement et sous<br>\
+  licence GPL v3. Cela signifie que vous pouvez l'utiliser et le copier<br>\
+  librement et que vous pouvez créer des travaux dérivés. Damian Brunold<br>\
+  ne peut assumer aucune responsabilité pour les bogues et les dommages<br>\
+  causés par l'utilisation du programme. Vous devez décider vous-même si<br>\
+  le programme vous est utile ou non. De plus amples informations sont<br>\
+  disponibles à l'adresse www.jbead.ch. Vous pouvez également y déposer<br>\
+  des demandes de fonctionnalités et des rapports de bogues.<br>\
+  Amusez-vous bien avec <b>jbead</b> !<br>
+
+print.failure = Erreur lors de l'impression du document
+
+updatecheck.uptodate = Jbead dispose de la dernière version à jour
+updatecheck.updateavailable = Une nouvelle version ({1}) de jbead est disponible au téléchargement
+updatecheck.failure = Erreur lors de la vérification de mise à jour : {1}.
+
+preferences.title = Préférences
+preferences.author = Auteur
+preferences.organization = Organisation
+preferences.symbols = Symboles des perles
+preferences.disablestartcheck = Désactiver la vérification des mises à jour lors du démarrage du programme


### PR DESCRIPTION
Here is a proposal for a French translation of your wonderful jbead ! I hope it corresponds to your convenience. Here I explain my choices.

Regarding the views, the term “patron” is more appropriate than “draft”. Indeed, I prefer to use the same word as in sewing. And "patron" is indeed the translation of "pattern". But the real pattern is the view at the left, while the second view is only a representation of the rope. And the third view is also a representation.

Consequently, i translate "Corrected" par "vue plane" : in French, "corrected" means that errors should be corrected or the view is not correctly diplayed. Instead, "vue plane" (plane view) fits better with the idea that we have a view like a planisphere.

Line 40-42 : Exit means Quit. In French "Quitter". So it would be better to use the Q letter. But as a non-programmer i prefer not replace the X letter. Reversely, CTRL+Y and CTRL+Z are the good combinations for a french user. (lines 56 and 61)

I'll leave it to you to correct the apostrophes `'` if need be.